### PR TITLE
Disable component governance detection

### DIFF
--- a/.ado/variables.yml
+++ b/.ado/variables.yml
@@ -2,4 +2,5 @@ variables:
   BuildWindowsSDK: 10.0.18362.0
   NugetArtifactId: Microsoft.Continuity
   runCodesignValidationInjection: false
+  skipComponentGovernanceDetection: true
 #  system.debug: true

--- a/change/@microsoft-continuity-2020-03-15-00-21-51-afoxman-disable-cgd.json
+++ b/change/@microsoft-continuity-2020-03-15-00-21-51-afoxman-disable-cgd.json
@@ -1,0 +1,9 @@
+{
+  "type": "none",
+  "comment": "Disable component governance detection. Not necessary for a purely C++ project. JS dependencies are for build tooling only.",
+  "packageName": "@microsoft/continuity",
+  "email": "adam@thefoxmans.net",
+  "commit": "e93c4588352f3f094c1b04e247f8ca1137f61f2a",
+  "dependentChangeType": "patch",
+  "date": "2020-03-15T07:21:50.922Z"
+}


### PR DESCRIPTION
Not necessary for a purely C++ project. JS dependencies are for build tooling only.