### PR TITLE
Restrict folly to SSE 2.0 to be compatible with CHPE opcode emulation…

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,14 +8,14 @@ The build is based on [CMake](https://cmake.org) and [Ninja](https://ninja-build
 
 ### Windows
 
-_If you already have Visual Studio 2019 installed with C++ tools, skip to step 3._
+_If you already have Visual Studio 2017 installed with C++ tools, skip to step 3._
 
-1. Install Visual Studio 2019 build tools
+1. Install Visual Studio 2017 build tools
 
 ```
-choco install visualstudio2019buildtools
-choco install visualstudio2019-workload-vctools
-choco install visualstudio2019-workload-universalbuildtools
+choco install visualstudio2017buildtools
+choco install visualstudio2017-workload-vctools
+choco install visualstudio2017-workload-universalbuildtools
 ```
 
 2. Install a [Windows 10 SDK](https://developer.microsoft.com/en-us/windows/downloads/sdk-archive). Choose a recent release. Don't go back any farther than `10.0.15063.0` (Spring Creators Update, version 1703).

--- a/scripts/build-windows.cmd
+++ b/scripts/build-windows.cmd
@@ -2,12 +2,12 @@
 SETLOCAL
 ECHO.
 
-ECHO [[ Looking for Visual C++ 2019... ]]
+ECHO [[ Looking for Visual C++ 2017... ]]
 
-SET VCVARSALL_BAT="%ProgramFiles(x86)%\Microsoft Visual Studio\2019\BuildTools\VC\Auxiliary\Build\vcvarsall.bat"
-IF NOT EXIST %VCVARSALL_BAT% set VCVARSALL_BAT="%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\vcvarsall.bat"
-IF NOT EXIST %VCVARSALL_BAT% set VCVARSALL_BAT="%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Professional\VC\Auxiliary\Build\vcvarsall.bat"
-IF NOT EXIST %VCVARSALL_BAT% set VCVARSALL_BAT="%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvarsall.bat"
+SET VCVARSALL_BAT="%ProgramFiles(x86)%\Microsoft Visual Studio\2017\BuildTools\VC\Auxiliary\Build\vcvarsall.bat"
+IF NOT EXIST %VCVARSALL_BAT% set VCVARSALL_BAT="%ProgramFiles(x86)%\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvarsall.bat"
+IF NOT EXIST %VCVARSALL_BAT% set VCVARSALL_BAT="%ProgramFiles(x86)%\Microsoft Visual Studio\2017\Professional\VC\Auxiliary\Build\vcvarsall.bat"
+IF NOT EXIST %VCVARSALL_BAT% set VCVARSALL_BAT="%ProgramFiles(x86)%\Microsoft Visual Studio\2017\Enterprise\VC\Auxiliary\Build\vcvarsall.bat"
 IF NOT EXIST %VCVARSALL_BAT% GOTO NoBuildTools
 
 CALL :RunArch x86
@@ -136,7 +136,7 @@ EXIT /b %ERRORLEVEL%
 
 
 :NoBuildTools
-ECHO [[ ERROR ]] Failed to find Visual C++ 2019 in any of the standard locations
+ECHO [[ ERROR ]] Failed to find Visual C++ 2017 in any of the standard locations
 EXIT /b 1
 
 :VCVarsError

--- a/src/Folly/CMakeLists.txt
+++ b/src/Folly/CMakeLists.txt
@@ -207,6 +207,11 @@ target_include_directories(folly
     PRIVATE
         ${BOOST_ROOT}/include)
 
+target_compile_definitions(folly
+    PUBLIC
+        FOLLY_SSE=2
+        FOLLY_SSE_MINOR=0)
+
 target_link_options(folly
     PUBLIC
         $<$<COMPILE_LANG_AND_ID:CXX,MSVC>:/NATVIS:${CMAKE_CURRENT_SOURCE_DIR}/Folly.natvis>)


### PR DESCRIPTION
…. Update docs/script to use VS2017 tools.